### PR TITLE
add dependabot and license check CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+    target-branch: "main"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    assignees:
+      - "takumiyoshikawa"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    target-branch: "main"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,28 @@
+name: Go License Check
+
+on:
+  pull_request:
+    paths:
+      - "go.mod"
+      - "go.sum"
+  push:
+    branches: [main]
+
+jobs:
+  check-licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Check licenses
+        run: |
+          go-licenses check ./... --include_tests --disallowed_types=permissive,forbidden,restricted


### PR DESCRIPTION
## Summary
- Dependabot設定を追加（Goモジュール・GitHub Actionsの週次自動更新）
- go-licensesによるライセンスチェックワークフローを追加

## Test plan
- [ ] license.yml が go.mod/go.sum 変更時に正しく実行されることを確認
- [ ] dependabot が週次でPRを作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)