### PR TITLE
docs: add Homebrew install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Chain multiple Claude Code skills together in a loop-based workflow. Define skil
 
 ## Installation
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install takumiyoshikawa/tap/skill-loop
+```
+
+### Go install
+
 ```bash
 go install github.com/takumiyoshikawa/skill-loop/cmd/skill-loop@latest
 ```


### PR DESCRIPTION
## Summary
- Add `brew install takumiyoshikawa/tap/skill-loop` instructions to README
- Organize Installation section with Homebrew and Go install subsections

## Test plan
- [ ] Verify `brew install takumiyoshikawa/tap/skill-loop` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)