### PR TITLE
Add blocked session HITL flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ skills:
       - id: approve
         criteria: "If the review says implementation quality is sufficient."
         done: true
+      - id: ask-human
+        criteria: "If the review needs a human decision before implementation can continue."
+        blocked: true
+        skill: 1-impl
       - id: rework
         criteria: "If review found issues that require more implementation work."
         skill: 1-impl
@@ -238,9 +242,35 @@ router:
 | `id`       | string | Yes      | Stable route identifier that the router agent returns                                                    |
 | `criteria` | string | Usually  | Judgment criteria used by the router when choosing this route. Required when a skill has multiple routes |
 | `skill`    | string | Conditional | Next skill to run. Required unless `done: true`                                                        |
-| `done`     | bool   | Conditional | Ends the workflow when selected. Required unless `skill` is set                                        |
+| `done`     | bool   | Conditional | Ends the workflow when selected. Mutually exclusive with `skill` and `blocked`                         |
+| `blocked`  | bool   | No       | Pause the workflow and mark the session `blocked` awaiting human input. Requires `skill`                |
 
 When a skill has exactly one route, skill-loop skips the router and selects that route automatically.
+
+### Human in the loop
+
+Use `blocked: true` when the workflow should stop and wait for a person:
+
+```yaml
+skills:
+  review:
+    next:
+      - id: approve
+        criteria: "Ready to ship"
+        done: true
+      - id: ask-human
+        criteria: "A human needs to choose the direction before continuing"
+        blocked: true
+        skill: implement
+```
+
+When that route is selected, the session moves to `blocked` and stores the next skill plus the handoff context. Resume it later with:
+
+```bash
+skill-loop sessions resume <session-id> --prompt "Use option 2 and keep the existing API shape."
+```
+
+The resume prompt is appended to the saved handoff before the workflow continues from the blocked route's `skill`.
 
 ## Sessions
 
@@ -265,6 +295,7 @@ skill-loop sessions logs <session-id> --stderr
 skill-loop sessions logs <session-id> --tail 200
 skill-loop sessions attach <session-id>
 skill-loop sessions stop <session-id>
+skill-loop sessions resume <session-id> --prompt "Reviewed. Continue with option B."
 skill-loop sessions prune
 skill-loop sessions prune --dry-run
 skill-loop sessions prune --all
@@ -272,6 +303,7 @@ skill-loop sessions prune --all
 
 `skill-loop run` also prints the session directory plus the captured `stdout.log` and `stderr.log` paths when a detached run starts.
 Scheduled sessions appear in `skill-loop sessions ls` with `scheduled` status and a `next:` timestamp. When a scheduled workflow is actively executing, the session switches to `running` and reports `iter: current/max`.
+If a route selects `blocked: true`, the run stops in `blocked` status until a human resumes it.
 Use `skill-loop sessions show` to launch the embedded React dashboard for the current repository and manage sessions from your browser.
 
 ## Architecture

--- a/cmd/skill-loop/commands/run.go
+++ b/cmd/skill-loop/commands/run.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -13,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/takumiyoshikawa/skill-loop/internal/config"
+	"github.com/takumiyoshikawa/skill-loop/internal/executor"
 	"github.com/takumiyoshikawa/skill-loop/internal/orchestrator"
 	"github.com/takumiyoshikawa/skill-loop/internal/scheduler"
 	"github.com/takumiyoshikawa/skill-loop/internal/session"
@@ -62,7 +65,22 @@ Use --attach to attach to that tmux session immediately.`,
 
 			// Child mode for detached orchestrator process.
 			if os.Getenv("SKILL_LOOP_RUN_CHILD") == "1" {
-				return orchestrator.Run(cfg, maxIterations, prompt, entrypoint)
+				runErr := orchestrator.RunWithObserver(
+					cfg,
+					maxIterations,
+					prompt,
+					entrypoint,
+					&defaultExecutor{},
+					newSessionRunObserver(os.Getenv("SKILL_LOOP_SESSION_REPO_ROOT"), os.Getenv("SKILL_LOOP_SESSION_ID")),
+				)
+				var blocked *orchestrator.BlockedError
+				if errors.As(runErr, &blocked) {
+					if err := persistBlockedSession(blocked); err != nil {
+						return err
+					}
+					return nil
+				}
+				return runErr
 			}
 
 			childArgs := buildRunChildArgs(cfgPath, maxIterations, prompt, entrypoint)
@@ -173,12 +191,16 @@ func startDetachedScheduledRun(cfg *config.Config, cfgPath string, workflowName 
 }
 
 func startDetachedSession(cfgPath string, workflowName string, childArgs []string, childEnv map[string]string) (*session.Metadata, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
+	configDir := filepath.Dir(cfgPath)
+	if configDir == "" || configDir == "." {
+		var err error
+		configDir, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("get working directory: %w", err)
+		}
 	}
 
-	repoRoot, err := session.ResolveRepoRoot(wd)
+	repoRoot, err := session.ResolveRepoRoot(configDir)
 	if err != nil {
 		return nil, err
 	}
@@ -187,22 +209,15 @@ func startDetachedSession(cfgPath string, workflowName string, childArgs []strin
 	if err != nil {
 		return nil, fmt.Errorf("resolve executable path: %w", err)
 	}
-	exePath, err = filepath.Abs(exePath)
+	exePath, err = resolveDetachedBinary(exePath)
 	if err != nil {
-		return nil, fmt.Errorf("resolve absolute executable path: %w", err)
+		return nil, err
 	}
 
 	command := append([]string{"env"}, envAssignments(childEnv)...)
 	command = append(command, exePath)
 	command = append(command, childArgs...)
-	workingDir := wd
-	// `go run` builds into a temporary location; use source invocation for detached child.
-	if strings.Contains(exePath, string(filepath.Separator)+"go-build") {
-		command = append([]string{"env"}, envAssignments(childEnv)...)
-		command = append(command, "go", "run", "./cmd/skill-loop")
-		command = append(command, childArgs...)
-		workingDir = repoRoot
-	}
+	workingDir := configDir
 
 	meta, err := session.New(repoRoot, workingDir, workflowName, "orchestrator", "skill-loop", command, 0, 0)
 	if err != nil {
@@ -232,4 +247,109 @@ func envAssignments(env map[string]string) []string {
 	}
 	sort.Strings(assignments)
 	return assignments
+}
+
+type defaultExecutor struct{}
+
+func (d *defaultExecutor) ExecuteSkill(name string, agent config.Agent, input string, opts executor.ExecutionOptions) (*executor.SkillResult, error) {
+	return executor.ExecuteSkill(name, agent, input, opts)
+}
+
+func (d *defaultExecutor) RouteSkillOutput(skillName string, router config.Agent, output string, routes []config.Route, opts executor.ExecutionOptions) (*executor.RouterDecision, error) {
+	return executor.RouteSkillOutput(skillName, router, output, routes, opts)
+}
+
+type sessionRunObserver struct {
+	repoRoot  string
+	sessionID string
+}
+
+func newSessionRunObserver(repoRoot string, sessionID string) orchestrator.RunObserver {
+	if strings.TrimSpace(repoRoot) == "" || strings.TrimSpace(sessionID) == "" {
+		return nil
+	}
+	return &sessionRunObserver{repoRoot: repoRoot, sessionID: sessionID}
+}
+
+func (o *sessionRunObserver) IterationStarted(iteration int, maxIterations int, skill string) {
+	_ = o.update(func(meta *session.Metadata) {
+		meta.Status = session.StatusRunning
+		meta.CurrentIteration = iteration
+		meta.MaxIterations = maxIterations
+		meta.CurrentSkill = skill
+	})
+}
+
+func (o *sessionRunObserver) SkillCompleted(iteration int, maxIterations int, skill string, stdout string) {
+	_ = o.update(func(meta *session.Metadata) {
+		meta.Status = session.StatusRunning
+		meta.CurrentIteration = iteration
+		meta.MaxIterations = maxIterations
+		meta.CurrentSkill = skill
+		meta.LastSkillOutput = stdout
+	})
+}
+
+func (o *sessionRunObserver) update(apply func(*session.Metadata)) error {
+	meta, err := session.LoadByID(o.repoRoot, o.sessionID)
+	if err != nil {
+		return err
+	}
+	apply(meta)
+	return session.Save(meta)
+}
+
+func resolveDetachedBinary(exePath string) (string, error) {
+	exePath, err := filepath.Abs(exePath)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute executable path: %w", err)
+	}
+
+	if !strings.Contains(exePath, string(filepath.Separator)+"go-build") {
+		return exePath, nil
+	}
+
+	installedPath, err := exec.LookPath("skill-loop")
+	if err != nil {
+		return "", fmt.Errorf("detached runs require an installed skill-loop binary on PATH when launched via go run: %w", err)
+	}
+	installedPath, err = filepath.Abs(installedPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve installed skill-loop path: %w", err)
+	}
+	return installedPath, nil
+}
+
+func persistBlockedSession(blocked *orchestrator.BlockedError) error {
+	sessionID := os.Getenv("SKILL_LOOP_SESSION_ID")
+	if sessionID == "" {
+		return fmt.Errorf("persist blocked session: SKILL_LOOP_SESSION_ID is required")
+	}
+
+	repoRoot := os.Getenv("SKILL_LOOP_SESSION_REPO_ROOT")
+	if repoRoot == "" {
+		var err error
+		repoRoot, err = session.ResolveRepoRoot("")
+		if err != nil {
+			return fmt.Errorf("persist blocked session: %w", err)
+		}
+	}
+
+	meta, err := session.LoadByID(repoRoot, sessionID)
+	if err != nil {
+		return fmt.Errorf("persist blocked session: %w", err)
+	}
+
+	now := time.Now().UTC()
+	meta.Status = session.StatusBlocked
+	meta.EndedAt = &now
+	meta.BlockReason = blocked.Reason
+	meta.ResumeSkill = blocked.Skill
+	meta.ResumePrompt = blocked.Prompt
+	meta.LastError = ""
+
+	if err := session.Save(meta); err != nil {
+		return fmt.Errorf("persist blocked session: %w", err)
+	}
+	return nil
 }

--- a/cmd/skill-loop/commands/run_test.go
+++ b/cmd/skill-loop/commands/run_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveDetachedBinaryUsesInstalledBinaryForGoRun(t *testing.T) {
+	binDir := t.TempDir()
+	binaryPath := filepath.Join(binDir, "skill-loop")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	//nolint:gosec // Test helper must be executable to stand in for the installed binary on PATH.
+	if err := os.Chmod(binaryPath, 0o755); err != nil {
+		t.Fatalf("Chmod() error: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	got, err := resolveDetachedBinary("/var/folders/tmp/go-build1234/b001/exe/skill-loop")
+	if err != nil {
+		t.Fatalf("resolveDetachedBinary() error: %v", err)
+	}
+	if got != binaryPath {
+		t.Fatalf("resolveDetachedBinary() = %q, want %q", got, binaryPath)
+	}
+}
+
+func TestResolveDetachedBinaryErrorsWhenInstalledBinaryMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := resolveDetachedBinary("/var/folders/tmp/go-build1234/b001/exe/skill-loop")
+	if err == nil || !strings.Contains(err.Error(), "installed skill-loop binary") {
+		t.Fatalf("resolveDetachedBinary() error = %v, want installed binary error", err)
+	}
+}

--- a/cmd/skill-loop/commands/sessions.go
+++ b/cmd/skill-loop/commands/sessions.go
@@ -30,6 +30,7 @@ func NewSessionsCmd() *cobra.Command {
 	cmd.AddCommand(newSessionsLogsCmd())
 	cmd.AddCommand(newSessionsAttachCmd())
 	cmd.AddCommand(newSessionsStopCmd())
+	cmd.AddCommand(newSessionsResumeCmd())
 	cmd.AddCommand(newSessionsPruneCmd())
 
 	return cmd
@@ -242,6 +243,56 @@ func newSessionsStopCmd() *cobra.Command {
 	}
 }
 
+func newSessionsResumeCmd() *cobra.Command {
+	var prompt string
+	var attach bool
+
+	cmd := &cobra.Command{
+		Use:   "resume <session-id>",
+		Short: "Resume a blocked run session with optional human input",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			meta, err := loadRunSessionByID(args[0])
+			if err != nil {
+				return err
+			}
+			if err := session.Reconcile(meta); err != nil {
+				return err
+			}
+			if meta.Schedule != "" {
+				return fmt.Errorf("resume is not supported for scheduled sessions")
+			}
+			if meta.Status != session.StatusBlocked {
+				return fmt.Errorf("session %s is not blocked", meta.ID)
+			}
+
+			command, err := session.BuildResumeCommand(meta, prompt)
+			if err != nil {
+				return err
+			}
+			if err := session.UpdateCommand(meta, command); err != nil {
+				return err
+			}
+			if err := session.Start(meta); err != nil {
+				return err
+			}
+
+			fmt.Printf("Resumed in background. run_id=%s\n", meta.ID)
+			fmt.Printf("Attach: skill-loop sessions attach %s\n", meta.ID)
+
+			if attach {
+				return session.Attach(meta)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&prompt, "prompt", "p", "", "Human input appended before resuming the workflow")
+	cmd.Flags().BoolVar(&attach, "attach", false, "Attach to the tmux session immediately after resuming")
+
+	return cmd
+}
+
 func newSessionsPruneCmd() *cobra.Command {
 	var dryRun bool
 	var all bool
@@ -380,6 +431,12 @@ func formatSessionDetails(meta *session.Metadata) string {
 	fmt.Fprintf(&b, "Stdout: %s\n", meta.StdoutPath)
 	fmt.Fprintf(&b, "Stderr: %s\n", meta.StderrPath)
 	fmt.Fprintf(&b, "Working dir: %s\n", meta.WorkingDir)
+	if meta.BlockReason != "" {
+		fmt.Fprintf(&b, "Block reason: %s\n", meta.BlockReason)
+	}
+	if meta.ResumeSkill != "" {
+		fmt.Fprintf(&b, "Resume skill: %s\n", meta.ResumeSkill)
+	}
 	if meta.LastError != "" {
 		fmt.Fprintf(&b, "Last error: %s\n", meta.LastError)
 	}
@@ -473,6 +530,14 @@ func formatSessionDetail(meta *session.Metadata) string {
 			return fmt.Sprintf("iter: %d/%d", meta.CurrentIteration, meta.MaxIterations)
 		}
 		return "last_output: " + meta.LastOutputAt.Local().Format(time.DateTime)
+	case session.StatusBlocked:
+		if meta.BlockReason != "" {
+			return "awaiting input: " + meta.BlockReason
+		}
+		if meta.ResumeSkill != "" {
+			return "awaiting input for " + meta.ResumeSkill
+		}
+		return "awaiting human input"
 	case session.StatusFailed, session.StatusStopped:
 		if meta.LastError != "" {
 			return meta.LastError

--- a/cmd/skill-loop/commands/sessions_test.go
+++ b/cmd/skill-loop/commands/sessions_test.go
@@ -58,7 +58,7 @@ func TestFormatSessionDetailsIncludesPathsAndError(t *testing.T) {
 	ended := now.Add(2 * time.Minute)
 	meta := &session.Metadata{
 		ID:           "session-123",
-		Status:       session.StatusFailed,
+		Status:       session.StatusBlocked,
 		StartedAt:    now,
 		LastOutputAt: now.Add(time.Minute),
 		EndedAt:      &ended,
@@ -66,19 +66,21 @@ func TestFormatSessionDetailsIncludesPathsAndError(t *testing.T) {
 		StdoutPath:   "/tmp/session-123/stdout.log",
 		StderrPath:   "/tmp/session-123/stderr.log",
 		WorkingDir:   "/repo",
-		LastError:    "agent exited with code 1",
+		BlockReason:  "waiting for review",
+		ResumeSkill:  "apply-feedback",
 	}
 
 	got := formatSessionDetails(meta)
 
 	for _, want := range []string{
 		"ID: session-123",
-		"Status: failed",
+		"Status: blocked",
 		"Session: /tmp/session-123",
 		"Stdout: /tmp/session-123/stdout.log",
 		"Stderr: /tmp/session-123/stderr.log",
 		"Working dir: /repo",
-		"Last error: agent exited with code 1",
+		"Block reason: waiting for review",
+		"Resume skill: apply-feedback",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("formatSessionDetails() missing %q\nfull output:\n%s", want, got)

--- a/e2e/.agents/skills/pass-through/SKILL.md
+++ b/e2e/.agents/skills/pass-through/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: pass-through
+description: Dummy pass-through skill for resume e2e runs
+---
+
+You are a dummy pass-through skill for testing blocked and resume behavior.
+Do not do any real work. Just respond with a summary.
+
+- If the input contains `ok`, respond with summary: `<APPROVED>`
+- Otherwise, respond with summary: `<NEEDS_HUMAN>`

--- a/e2e/.claude/skills/pass-through/SKILL.md
+++ b/e2e/.claude/skills/pass-through/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: pass-through
+description: Dummy pass-through skill for resume e2e runs
+---
+
+You are a dummy pass-through skill for testing blocked and resume behavior.
+
+Look at the Input Requirements.
+- If it contains `ok`, respond `<APPROVED>`
+- Otherwise, respond `<NEEDS_HUMAN>`

--- a/e2e/hello-schedule.yml
+++ b/e2e/hello-schedule.yml
@@ -9,7 +9,7 @@ skills:
   hello:
     agent:
       runtime: claude
-      model: claude-sonnet-4.6
+      model: claude-sonnet-4-6
       args:
         - "--dangerously-skip-permissions"
     next:

--- a/e2e/resume.yml
+++ b/e2e/resume.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/takumiyoshikawa/skill-loop/refs/heads/main/schema.json
+
+name: e2e-resume
+default_entrypoint: pass-through
+max_iterations: 2
+router:
+  runtime: codex
+  model: gpt-5.4
+  args:
+    - "--full-auto"
+
+skills:
+  pass-through:
+    agent:
+      runtime: claude
+      model: claude-sonnet-4-6
+      args:
+        - "--dangerously-skip-permissions"
+    next:
+      - id: approve
+        criteria: "If the skill output contains <APPROVED>, finish the workflow."
+        done: true
+      - id: ask-human
+        criteria: "If the skill output contains <NEEDS_HUMAN>, block and wait for a human to resume."
+        blocked: true
+        skill: pass-through

--- a/e2e/skill-loop.yml
+++ b/e2e/skill-loop.yml
@@ -4,16 +4,16 @@ name: e2e-skill-loop
 default_entrypoint: 1-impl
 max_iterations: 5
 router:
-  runtime: codex
-  model: gpt-5.4
+  runtime: claude
+  model: claude-sonnet-4-6
   args:
-    - "--full-auto"
+    - "--dangerously-skip-permissions"
 
 skills:
   1-impl:
     agent:
       runtime: claude
-      model: claude-sonnet-4.6
+      model: claude-sonnet-4-6
       args:
         - "--dangerously-skip-permissions"
     next:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Route struct {
 	Criteria   string `yaml:"criteria,omitempty" jsonschema:"description=Judgment criteria used by the router agent when deciding whether this route should be chosen."`
 	Skill      string `yaml:"skill,omitempty" jsonschema:"description=Target skill name to route to. Mutually exclusive with done."`
 	Done       bool   `yaml:"done,omitempty" jsonschema:"description=Terminate the workflow when this route is selected. Mutually exclusive with skill."`
+	Blocked    bool   `yaml:"blocked,omitempty" jsonschema:"description=Pause the workflow and mark the session blocked awaiting human input. Requires skill and is mutually exclusive with done."`
 	LegacyWhen string `yaml:"when,omitempty" json:"-" jsonschema:"-"`
 }
 
@@ -113,10 +114,16 @@ func Load(path string) (*Config, error) {
 				return nil, fmt.Errorf("skill %q: route[%d] requires criteria when multiple routes are present", name, i)
 			}
 			if route.Done {
+				if route.Blocked {
+					return nil, fmt.Errorf("skill %q: route[%d] cannot set both done and blocked", name, i)
+				}
 				if route.Skill != "" {
 					return nil, fmt.Errorf("skill %q: route[%d] cannot set both done and skill", name, i)
 				}
 				continue
+			}
+			if route.Blocked && route.Skill == "" {
+				return nil, fmt.Errorf("skill %q: route[%d] must set skill when blocked is true", name, i)
 			}
 			if route.Skill == "" {
 				return nil, fmt.Errorf("skill %q: route[%d] must set either skill or done", name, i)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -227,6 +227,54 @@ skills:
 	}
 }
 
+func TestLoadRejectsRouteWithDoneAndBlocked(t *testing.T) {
+	_, err := Load(writeConfig(t, `default_entrypoint: impl
+skills:
+  impl:
+    next:
+      - id: bad
+        done: true
+        blocked: true
+`))
+	if err == nil {
+		t.Error("Load() should return error when route sets both done and blocked")
+	}
+}
+
+func TestLoadRejectsBlockedRouteWithoutSkill(t *testing.T) {
+	_, err := Load(writeConfig(t, `default_entrypoint: impl
+skills:
+  impl:
+    next:
+      - id: need-human
+        blocked: true
+`))
+	if err == nil {
+		t.Error("Load() should return error when blocked route has no skill")
+	}
+}
+
+func TestLoadAllowsBlockedRouteWithSkill(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `default_entrypoint: impl
+skills:
+  impl:
+    next:
+      - id: need-human
+        blocked: true
+        skill: confirm
+  confirm:
+    next:
+      - id: done
+        done: true
+`))
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if !cfg.Skills["impl"].Next[0].Blocked {
+		t.Fatal("expected blocked route to be preserved")
+	}
+}
+
 func TestLoadRequiresRouterForMultiRouteSkills(t *testing.T) {
 	_, err := Load(writeConfig(t, `default_entrypoint: impl
 skills:

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -19,6 +19,21 @@ type SkillExecutor interface {
 
 type RunObserver interface {
 	IterationStarted(iteration int, maxIterations int, skill string)
+	SkillCompleted(iteration int, maxIterations int, skill string, stdout string)
+}
+
+type BlockedError struct {
+	RouteID string
+	Reason  string
+	Skill   string
+	Prompt  string
+}
+
+func (e *BlockedError) Error() string {
+	if strings.TrimSpace(e.Reason) != "" {
+		return fmt.Sprintf("workflow blocked on route %q: %s", e.RouteID, e.Reason)
+	}
+	return fmt.Sprintf("workflow blocked on route %q", e.RouteID)
 }
 
 type defaultExecutor struct{}
@@ -87,6 +102,9 @@ func runWith(cfg *config.Config, maxIterations int, prompt string, entrypoint st
 		if err != nil {
 			return fmt.Errorf("skill %q failed: %w", currentSkill, err)
 		}
+		if observer != nil {
+			observer.SkillCompleted(i+1, maxIterations, currentSkill, result.Stdout)
+		}
 
 		route, reason, err := selectRoute(exec, cfg.Router, currentSkill, skill.Next, result.Stdout, opts)
 		if err != nil {
@@ -104,11 +122,20 @@ func runWith(cfg *config.Config, maxIterations int, prompt string, entrypoint st
 			return nil
 		}
 
+		handoff = buildHandoff(currentSkill, route.ID, reason, result.Stdout)
+		if route.Blocked {
+			return &BlockedError{
+				RouteID: route.ID,
+				Reason:  reason,
+				Skill:   route.Skill,
+				Prompt:  handoff,
+			}
+		}
+
 		if _, ok := cfg.Skills[route.Skill]; !ok {
 			return fmt.Errorf("next skill %q (resolved from route %q) not found in config", route.Skill, route.ID)
 		}
 
-		handoff = buildHandoff(currentSkill, route.ID, reason, result.Stdout)
 		currentSkill = route.Skill
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -32,12 +32,17 @@ type mockObserver struct {
 	iterations []int
 	maxes      []int
 	skills     []string
+	completed  []string
 }
 
 func (m *mockObserver) IterationStarted(iteration int, maxIterations int, skill string) {
 	m.iterations = append(m.iterations, iteration)
 	m.maxes = append(m.maxes, maxIterations)
 	m.skills = append(m.skills, skill)
+}
+
+func (m *mockObserver) SkillCompleted(iteration int, maxIterations int, skill string, stdout string) {
+	m.completed = append(m.completed, stdout)
 }
 
 func (m *mockExecutor) ExecuteSkill(name string, agent config.Agent, input string, opts executor.ExecutionOptions) (*executor.SkillResult, error) {
@@ -182,6 +187,46 @@ func TestRunRouterError(t *testing.T) {
 	}
 }
 
+func TestRunReturnsBlockedError(t *testing.T) {
+	cfg := &config.Config{
+		DefaultEntrypoint: "review",
+		Skills: map[string]config.Skill{
+			"review": {
+				Next: []config.Route{{
+					ID:      "need-human",
+					Blocked: true,
+					Skill:   "apply-feedback",
+				}},
+			},
+			"apply-feedback": {
+				Next: []config.Route{{ID: "done", Done: true}},
+			},
+		},
+	}
+
+	mock := &mockExecutor{
+		skillCalls: []mockSkillCall{
+			{result: &executor.SkillResult{Stdout: "Need human approval"}},
+		},
+	}
+
+	err := RunWith(cfg, 10, "start here", "", mock)
+	var blocked *BlockedError
+	if err == nil || !strings.Contains(err.Error(), "workflow blocked") {
+		t.Fatalf("RunWith() error = %v, want blocked error", err)
+	}
+	if _, ok := err.(*BlockedError); !ok {
+		t.Fatalf("RunWith() error type = %T, want *BlockedError", err)
+	}
+	blocked = err.(*BlockedError)
+	if blocked.Skill != "apply-feedback" {
+		t.Fatalf("blocked skill = %q, want apply-feedback", blocked.Skill)
+	}
+	if !strings.Contains(blocked.Prompt, "Previous skill: review") {
+		t.Fatalf("blocked prompt = %q, want previous skill handoff", blocked.Prompt)
+	}
+}
+
 func TestRunMaxIterationsReached(t *testing.T) {
 	cfg := &config.Config{
 		DefaultEntrypoint: "impl",
@@ -224,6 +269,31 @@ func TestRunDefaultMaxIterations(t *testing.T) {
 
 	if err := RunWith(cfg, 0, "", "", mock); err != nil {
 		t.Fatalf("RunWith() error: %v", err)
+	}
+}
+
+func TestRunObserverReceivesSkillOutput(t *testing.T) {
+	cfg := &config.Config{
+		DefaultEntrypoint: "review",
+		Skills: map[string]config.Skill{
+			"review": {
+				Next: []config.Route{{ID: "approve", Done: true}},
+			},
+		},
+	}
+
+	mock := &mockExecutor{
+		skillCalls: []mockSkillCall{
+			{result: &executor.SkillResult{Stdout: "final summary"}},
+		},
+	}
+	observer := &mockObserver{}
+
+	if err := RunWithObserver(cfg, 10, "", "", mock, observer); err != nil {
+		t.Fatalf("RunWithObserver() error: %v", err)
+	}
+	if len(observer.completed) != 1 || observer.completed[0] != "final summary" {
+		t.Fatalf("completed outputs = %v, want [final summary]", observer.completed)
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -17,12 +18,19 @@ import (
 )
 
 type progressObserver struct {
-	onIteration func(iteration int, maxIterations int, skill string)
+	onIteration     func(iteration int, maxIterations int, skill string)
+	onSkillComplete func(iteration int, maxIterations int, skill string, stdout string)
 }
 
 func (p *progressObserver) IterationStarted(iteration int, maxIterations int, skill string) {
 	if p.onIteration != nil {
 		p.onIteration(iteration, maxIterations, skill)
+	}
+}
+
+func (p *progressObserver) SkillCompleted(iteration int, maxIterations int, skill string, stdout string) {
+	if p.onSkillComplete != nil {
+		p.onSkillComplete(iteration, maxIterations, skill, stdout)
 	}
 }
 
@@ -65,6 +73,9 @@ func Run(repoRoot string, sessionID string, cfg *config.Config, maxIterations in
 			meta.CurrentIteration = 0
 			meta.MaxIterations = maxIterations
 			meta.CurrentSkill = ""
+			meta.BlockReason = ""
+			meta.ResumeSkill = ""
+			meta.ResumePrompt = ""
 			meta.LastError = lastErr
 			meta.EndedAt = nil
 		})
@@ -79,6 +90,16 @@ func Run(repoRoot string, sessionID string, cfg *config.Config, maxIterations in
 	running := false
 
 	_, err = c.AddFunc(cfg.Schedule, func() {
+		meta, loadErr := session.LoadByID(repoRoot, sessionID)
+		if loadErr != nil {
+			fmt.Fprintf(os.Stderr, "scheduled run skipped: failed to load session metadata: %v\n", loadErr)
+			return
+		}
+		if meta.Status == session.StatusBlocked {
+			fmt.Fprintln(os.Stderr, "scheduled run skipped: session is blocked awaiting human input")
+			return
+		}
+
 		runMu.Lock()
 		if running {
 			runMu.Unlock()
@@ -100,6 +121,9 @@ func Run(repoRoot string, sessionID string, cfg *config.Config, maxIterations in
 			meta.CurrentIteration = 0
 			meta.MaxIterations = maxIterations
 			meta.CurrentSkill = ""
+			meta.BlockReason = ""
+			meta.ResumeSkill = ""
+			meta.ResumePrompt = ""
 			meta.LastError = ""
 			meta.EndedAt = nil
 		}); err != nil {
@@ -117,9 +141,36 @@ func Run(repoRoot string, sessionID string, cfg *config.Config, maxIterations in
 					fmt.Fprintf(os.Stderr, "failed to persist session progress: %v\n", err)
 				}
 			},
+			onSkillComplete: func(iteration int, maxIters int, skill string, stdout string) {
+				if err := updateMeta(func(meta *session.Metadata) {
+					meta.Status = session.StatusRunning
+					meta.CurrentIteration = iteration
+					meta.MaxIterations = maxIters
+					meta.CurrentSkill = skill
+					meta.LastSkillOutput = stdout
+				}); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to persist session output: %v\n", err)
+				}
+			},
 		}
 
 		runErr := orchestrator.RunObserved(cfg, maxIterations, prompt, entrypoint, observer)
+		var blocked *orchestrator.BlockedError
+		if errors.As(runErr, &blocked) {
+			now := time.Now().UTC()
+			if err := updateMeta(func(meta *session.Metadata) {
+				meta.Status = session.StatusBlocked
+				meta.NextRun = nil
+				meta.BlockReason = blocked.Reason
+				meta.ResumeSkill = blocked.Skill
+				meta.ResumePrompt = blocked.Prompt
+				meta.LastError = ""
+				meta.EndedAt = &now
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to persist blocked session state: %v\n", err)
+			}
+			return
+		}
 		if runErr != nil {
 			fmt.Fprintf(os.Stderr, "scheduled run failed: %v\n", runErr)
 			if err := updateScheduled(runErr.Error()); err != nil {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -26,6 +26,7 @@ const (
 	StatusPending   Status = "pending"
 	StatusScheduled Status = "scheduled"
 	StatusRunning   Status = "running"
+	StatusBlocked   Status = "blocked"
 	StatusIdle      Status = "idle"
 	StatusDone      Status = "done"
 	StatusFailed    Status = "failed"
@@ -57,6 +58,10 @@ type Metadata struct {
 	CurrentIteration   int        `json:"current_iteration,omitempty"`
 	MaxIterations      int        `json:"max_iterations,omitempty"`
 	CurrentSkill       string     `json:"current_skill,omitempty"`
+	LastSkillOutput    string     `json:"last_skill_output,omitempty"`
+	BlockReason        string     `json:"block_reason,omitempty"`
+	ResumeSkill        string     `json:"resume_skill,omitempty"`
+	ResumePrompt       string     `json:"resume_prompt,omitempty"`
 	IdleTimeoutSeconds int        `json:"idle_timeout_seconds"`
 	MaxRestarts        int        `json:"max_restarts"`
 	RestartCount       int        `json:"restart_count"`
@@ -186,6 +191,18 @@ func Save(meta *Metadata) error {
 	return nil
 }
 
+func UpdateCommand(meta *Metadata, command []string) error {
+	if len(command) == 0 {
+		return fmt.Errorf("command is required")
+	}
+	meta.Command = append([]string(nil), command...)
+	meta.WorkingDir = preferredWorkingDir(meta.ConfigPath, meta.WorkingDir)
+	if err := writeScript(meta); err != nil {
+		return err
+	}
+	return Save(meta)
+}
+
 func LoadByID(repoRoot string, id string) (*Metadata, error) {
 	sessionFilePath, err := sessionFileByID(repoRoot, id)
 	if err != nil {
@@ -290,6 +307,10 @@ func Start(meta *Metadata) error {
 	}
 	meta.Status = StatusRunning
 	meta.EndedAt = nil
+	meta.BlockReason = ""
+	meta.ResumeSkill = ""
+	meta.ResumePrompt = ""
+	meta.LastError = ""
 	if meta.LastOutputAt.IsZero() {
 		meta.LastOutputAt = meta.StartedAt
 	}
@@ -316,6 +337,9 @@ func Stop(meta *Metadata) error {
 	now := time.Now().UTC()
 	meta.Status = StatusStopped
 	meta.EndedAt = &now
+	meta.BlockReason = ""
+	meta.ResumeSkill = ""
+	meta.ResumePrompt = ""
 	meta.LastError = ""
 	return Save(meta)
 }
@@ -343,11 +367,23 @@ func Reconcile(meta *Metadata) error {
 		}
 
 		now := time.Now().UTC()
+		if meta.Status == StatusBlocked {
+			if meta.EndedAt == nil {
+				meta.EndedAt = &now
+			}
+			return Save(meta)
+		}
 		if exitCode == 0 {
 			meta.Status = StatusDone
+			meta.BlockReason = ""
+			meta.ResumeSkill = ""
+			meta.ResumePrompt = ""
 			meta.LastError = ""
 		} else {
 			meta.Status = StatusFailed
+			meta.BlockReason = ""
+			meta.ResumeSkill = ""
+			meta.ResumePrompt = ""
 			meta.LastError = fmt.Sprintf("agent exited with code %d", exitCode)
 		}
 		if meta.EndedAt == nil {
@@ -382,6 +418,82 @@ func Reconcile(meta *Metadata) error {
 	}
 
 	return nil
+}
+
+func BuildResumeCommand(meta *Metadata, humanInput string) ([]string, error) {
+	if meta.Status != StatusBlocked {
+		return nil, fmt.Errorf("session %s is not blocked", meta.ID)
+	}
+	if meta.Schedule != "" {
+		return nil, fmt.Errorf("resume is not supported for scheduled sessions")
+	}
+	if meta.ConfigPath == "" {
+		return nil, fmt.Errorf("session %s is missing config_path", meta.ID)
+	}
+	if meta.ResumeSkill == "" {
+		return nil, fmt.Errorf("session %s is missing resume_skill", meta.ID)
+	}
+	if len(meta.Command) == 0 {
+		return nil, fmt.Errorf("session %s is missing command template", meta.ID)
+	}
+
+	runIdx := -1
+	for i := len(meta.Command) - 1; i >= 0; i-- {
+		arg := meta.Command[i]
+		if arg == "run" {
+			runIdx = i
+			break
+		}
+	}
+	if runIdx == -1 {
+		return nil, fmt.Errorf("session %s command does not contain run subcommand", meta.ID)
+	}
+	if runIdx+1 >= len(meta.Command) {
+		return nil, fmt.Errorf("session %s command is missing config path", meta.ID)
+	}
+
+	command := append([]string(nil), meta.Command[:runIdx+2]...)
+	command[runIdx+1] = meta.ConfigPath
+
+	skipNext := false
+	for _, arg := range meta.Command[runIdx+2:] {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		switch arg {
+		case "--prompt", "-p", "--entrypoint", "-e":
+			skipNext = true
+		default:
+			command = append(command, arg)
+		}
+	}
+
+	prompt := strings.TrimSpace(meta.ResumePrompt)
+	humanInput = strings.TrimSpace(humanInput)
+	switch {
+	case prompt != "" && humanInput != "":
+		prompt += "\n\nHuman input:\n" + humanInput
+	case humanInput != "":
+		prompt = humanInput
+	}
+	if prompt != "" {
+		command = append(command, "--prompt", prompt)
+	}
+	command = append(command, "--entrypoint", meta.ResumeSkill)
+
+	return command, nil
+}
+
+func preferredWorkingDir(configPath string, fallback string) string {
+	if strings.TrimSpace(configPath) == "" {
+		return fallback
+	}
+	dir := filepath.Dir(configPath)
+	if dir == "" || dir == "." {
+		return fallback
+	}
+	return dir
 }
 
 func HasTMuxSession(name string) (bool, error) {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -328,6 +329,148 @@ exit 0
 
 	if meta.Status != StatusScheduled {
 		t.Fatalf("status = %s, want %s", meta.Status, StatusScheduled)
+	}
+}
+
+func TestReconcileKeepsBlockedStatusWhenExitCodeExists(t *testing.T) {
+	tempDir := t.TempDir()
+	exitCodePath := filepath.Join(tempDir, "exit.code")
+	if err := os.WriteFile(exitCodePath, []byte("0\n"), 0o600); err != nil {
+		t.Fatalf("failed to write exit code: %v", err)
+	}
+
+	meta := &Metadata{
+		ID:           "blocked-session",
+		RepoRoot:     tempDir,
+		ScriptPath:   filepath.Join(tempDir, "run.sh"),
+		ExitCodePath: exitCodePath,
+		StdoutPath:   filepath.Join(tempDir, "stdout.log"),
+		StderrPath:   filepath.Join(tempDir, "stderr.log"),
+		TmuxSession:  "skill-loop-blocked-session",
+		Status:       StatusBlocked,
+		BlockReason:  "waiting for human approval",
+		ResumeSkill:  "apply-feedback",
+		ResumePrompt: "base handoff",
+		StartedAt:    time.Now().UTC(),
+		LastOutputAt: time.Now().UTC(),
+	}
+
+	if err := Reconcile(meta); err != nil {
+		t.Fatalf("Reconcile() error: %v", err)
+	}
+	if meta.Status != StatusBlocked {
+		t.Fatalf("status = %s, want %s", meta.Status, StatusBlocked)
+	}
+	if meta.EndedAt == nil {
+		t.Fatal("expected blocked reconcile to set ended_at")
+	}
+}
+
+func TestBuildResumeCommand(t *testing.T) {
+	meta := &Metadata{
+		ID:          "blocked-session",
+		Status:      StatusBlocked,
+		ConfigPath:  "/repo/skill-loop.yml",
+		ResumeSkill: "apply-feedback",
+		ResumePrompt: strings.Join([]string{
+			"Previous skill: review",
+			"",
+			"Previous skill stdout:",
+			"needs a human",
+		}, "\n"),
+		Command: []string{
+			"env",
+			"SKILL_LOOP_RUN_CHILD=1",
+			"/usr/local/bin/skill-loop",
+			"run",
+			"/repo/original.yml",
+			"--max-iterations",
+			"5",
+			"--prompt",
+			"old prompt",
+			"--entrypoint",
+			"review",
+		},
+	}
+
+	command, err := BuildResumeCommand(meta, "Please continue")
+	if err != nil {
+		t.Fatalf("BuildResumeCommand() error: %v", err)
+	}
+
+	got := strings.Join(command, "\n")
+	for _, want := range []string{
+		"/repo/skill-loop.yml",
+		"--max-iterations",
+		"5",
+		"--entrypoint",
+		"apply-feedback",
+		"Human input:\nPlease continue",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("BuildResumeCommand() missing %q\nfull command:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildResumeCommandWithGoRunTemplate(t *testing.T) {
+	meta := &Metadata{
+		ID:          "blocked-session",
+		Status:      StatusBlocked,
+		ConfigPath:  "/repo/e2e/resume.yml",
+		ResumeSkill: "pass-through",
+		ResumePrompt: strings.Join([]string{
+			"Previous skill: pass-through",
+			"",
+			"Previous skill stdout:",
+			"<NEEDS_HUMAN>",
+		}, "\n"),
+		Command: []string{
+			"env",
+			"SKILL_LOOP_RUN_CHILD=1",
+			"go",
+			"run",
+			"./cmd/skill-loop",
+			"run",
+			"/repo/old.yml",
+			"--max-iterations",
+			"2",
+		},
+	}
+
+	command, err := BuildResumeCommand(meta, "ok")
+	if err != nil {
+		t.Fatalf("BuildResumeCommand() error: %v", err)
+	}
+	if strings.Join(command[:5], " ") != "env SKILL_LOOP_RUN_CHILD=1 go run ./cmd/skill-loop" {
+		t.Fatalf("unexpected command prefix: %q", strings.Join(command, " "))
+	}
+	if command[5] != "run" || command[6] != "/repo/e2e/resume.yml" {
+		t.Fatalf("unexpected run/config segment: %v", command)
+	}
+}
+
+func TestUpdateCommandPrefersConfigDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	meta := &Metadata{
+		ConfigPath:   filepath.Join(tempDir, "e2e", "resume.yml"),
+		WorkingDir:   tempDir,
+		ScriptPath:   filepath.Join(tempDir, "run.sh"),
+		StdoutPath:   filepath.Join(tempDir, "stdout.log"),
+		StderrPath:   filepath.Join(tempDir, "stderr.log"),
+		ExitCodePath: filepath.Join(tempDir, "exit.code"),
+		Command:      []string{"echo", "hello"},
+	}
+	if err := os.MkdirAll(filepath.Dir(meta.ConfigPath), 0o750); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+
+	if err := UpdateCommand(meta, []string{"echo", "updated"}); err != nil {
+		t.Fatalf("UpdateCommand() error: %v", err)
+	}
+
+	if meta.WorkingDir != filepath.Dir(meta.ConfigPath) {
+		t.Fatalf("workingDir = %q, want %q", meta.WorkingDir, filepath.Dir(meta.ConfigPath))
 	}
 }
 

--- a/internal/sessionui/frontend/src/App.tsx
+++ b/internal/sessionui/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { SessionContent } from "./components/SessionContent";
 import { Sidebar } from "./components/Sidebar";
 import type { LogPayload, Session, SessionStatus, SessionsPayload } from "./types";
-import { getErrorMessage, getJSON, groupSessions, send, sendJSON } from "./utils";
+import { getErrorMessage, getJSON, groupSessions, sendJSON } from "./utils";
 
 const POLL_MS = 4000;
 
@@ -18,6 +18,7 @@ export default function App() {
   const [mutating, setMutating] = useState(false);
   const [error, setError] = useState("");
   const [flash, setFlash] = useState("");
+  const [resumeDraft, setResumeDraft] = useState("");
 
   useEffect(() => {
     let cancelled = false;
@@ -62,6 +63,10 @@ export default function App() {
   );
 
   useEffect(() => {
+    setResumeDraft("");
+  }, [selectedId]);
+
+  useEffect(() => {
     if (!selectedSession) {
       setLog(null);
       return;
@@ -70,11 +75,11 @@ export default function App() {
     let cancelled = false;
     const refreshLog = async () => {
       try {
-        const payload = await getJSON<LogPayload>(
+        const activePayload = await getJSON<LogPayload>(
           `/api/sessions/${selectedSession.id}/logs/${activeStream}`,
         );
         if (!cancelled) {
-          setLog(payload);
+          setLog(activePayload);
         }
       } catch (err) {
         if (!cancelled) {
@@ -154,18 +159,21 @@ export default function App() {
     }
   }
 
-  async function deleteSelected() {
+  async function resumeSelected(prompt: string) {
     if (!selectedSession) {
-      return;
-    }
-    if (!window.confirm(`Delete session ${selectedSession.id}?`)) {
       return;
     }
     setMutating(true);
     try {
-      await send(`/api/sessions/${selectedSession.id}`, { method: "DELETE" });
-      setSessions((current) => current.filter((session) => session.id !== selectedSession.id));
-      setFlash(`Deleted ${selectedSession.id}`);
+      const payload = await sendJSON<Session>(`/api/sessions/${selectedSession.id}/resume`, {
+        method: "POST",
+        body: JSON.stringify({ prompt }),
+      });
+      setSessions((current) =>
+        current.map((session) => (session.id === payload.id ? payload : session)),
+      );
+      setResumeDraft("");
+      setFlash(`Resumed ${payload.id}`);
       setError("");
     } catch (err) {
       setError(getErrorMessage(err));
@@ -226,10 +234,12 @@ export default function App() {
         log={log}
         activeStream={activeStream}
         mutating={mutating}
+        resumeDraft={resumeDraft}
         onPruneInactive={() => void prune(true)}
         onRefreshSelected={() => void refreshSelected()}
         onStopSelected={() => void stopSelected()}
-        onDeleteSelected={() => void deleteSelected()}
+        onResumeDraftChange={setResumeDraft}
+        onResumeSelected={(prompt) => void resumeSelected(prompt)}
         onActiveStreamChange={setActiveStream}
       />
 

--- a/internal/sessionui/frontend/src/components/SessionContent.tsx
+++ b/internal/sessionui/frontend/src/components/SessionContent.tsx
@@ -1,4 +1,4 @@
-import { formatCompactDate } from "../utils";
+import { FormEvent } from "react";
 import type { LogPayload, Session } from "../types";
 
 type SessionContentProps = {
@@ -6,10 +6,12 @@ type SessionContentProps = {
   log: LogPayload | null;
   activeStream: "stdout" | "stderr";
   mutating: boolean;
+  resumeDraft: string;
   onPruneInactive: () => void;
   onRefreshSelected: () => void;
   onStopSelected: () => void;
-  onDeleteSelected: () => void;
+  onResumeDraftChange: (value: string) => void;
+  onResumeSelected: (prompt: string) => void;
   onActiveStreamChange: (stream: "stdout" | "stderr") => void;
 };
 
@@ -18,12 +20,19 @@ export function SessionContent({
   log,
   activeStream,
   mutating,
+  resumeDraft,
   onPruneInactive,
   onRefreshSelected,
   onStopSelected,
-  onDeleteSelected,
+  onResumeDraftChange,
+  onResumeSelected,
   onActiveStreamChange,
 }: SessionContentProps) {
+  function handleResumeSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onResumeSelected(resumeDraft);
+  }
+
   return (
     <main className="content">
       <header className="content-header">
@@ -51,18 +60,6 @@ export function SessionContent({
               >
                 Stop
               </button>
-              <button
-                type="button"
-                className="danger-button"
-                onClick={onDeleteSelected}
-                disabled={
-                  mutating ||
-                  selectedSession.status === "running" ||
-                  selectedSession.status === "scheduled"
-                }
-              >
-                Delete
-              </button>
             </>
           ) : null}
         </div>
@@ -71,37 +68,29 @@ export function SessionContent({
       {selectedSession ? (
         <div className="content-body">
           <section className="summary-card">
-            <p className="eyebrow">Description</p>
-            <div className="session-title">
-              <span className={`status-pill status-${selectedSession.status}`}>
-                {selectedSession.status}
-              </span>
-              <h3>{selectedSession.id}</h3>
+            <div className="summary-section summary-section-top">
+              <span className="section-label">Previous summary</span>
+              <pre className="summary-output">
+                {selectedSession.previousSummary || "(empty)"}
+              </pre>
             </div>
-            <div className="meta-grid">
-              <Meta label="Workflow" value={selectedSession.workflowName} />
-              <Meta label="Config" value={selectedSession.configName} />
-              <Meta label="Runtime" value={selectedSession.runtime} />
-              <Meta label="Started" value={formatCompactDate(selectedSession.startedAt)} />
-              <Meta label="Last output" value={formatCompactDate(selectedSession.lastOutputAt)} />
-              <Meta
-                label="Iterations"
-                value={
-                  selectedSession.maxIterations
-                    ? `${selectedSession.currentIteration ?? 0}/${selectedSession.maxIterations}`
-                    : "-"
-                }
-              />
-            </div>
-            <div className="inline-detail-list">
-              <InlineDetail label="Working dir" value={selectedSession.workingDir} />
-              <InlineDetail label="Session dir" value={selectedSession.sessionDir} />
-              <InlineDetail label="stdout" value={selectedSession.stdoutPath} />
-              <InlineDetail label="stderr" value={selectedSession.stderrPath} />
-              <InlineDetail label="Command" value={selectedSession.command.join(" ")} mono />
-            </div>
-            {selectedSession.lastError ? (
-              <div className="error-banner">{selectedSession.lastError}</div>
+            {selectedSession.status === "blocked" ? (
+              <form className="resume-form" onSubmit={handleResumeSubmit}>
+                <div className="resume-header">
+                  <div>
+                    <span className="section-label">Resume prompt</span>
+                  </div>
+                  <button type="submit" className="secondary-button" disabled={mutating}>
+                    Resume
+                  </button>
+                </div>
+                <textarea
+                  value={resumeDraft}
+                  onChange={(event) => onResumeDraftChange(event.target.value)}
+                  placeholder="Add human guidance, approval, or constraints here."
+                  disabled={mutating}
+                />
+              </form>
             ) : null}
           </section>
 
@@ -135,31 +124,5 @@ export function SessionContent({
         </section>
       )}
     </main>
-  );
-}
-
-function Meta({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="meta-item">
-      <span>{label}</span>
-      <strong>{value}</strong>
-    </div>
-  );
-}
-
-function InlineDetail({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className="inline-detail">
-      <span>{label}</span>
-      <code className={mono ? "mono" : undefined}>{value}</code>
-    </div>
   );
 }

--- a/internal/sessionui/frontend/src/components/Sidebar.tsx
+++ b/internal/sessionui/frontend/src/components/Sidebar.tsx
@@ -84,9 +84,6 @@ export function Sidebar({
         <div>
           <p className="eyebrow">Workspace</p>
           <h1>{repoName}</h1>
-          <p className="sidebar-path" title={repoRoot}>
-            {repoRoot}
-          </p>
         </div>
         <button type="button" className="secondary-button compact" onClick={onRefresh}>
           Refresh

--- a/internal/sessionui/frontend/src/styles.css
+++ b/internal/sessionui/frontend/src/styles.css
@@ -25,6 +25,10 @@ input {
   font: inherit;
 }
 
+textarea {
+  font: inherit;
+}
+
 button {
   cursor: pointer;
 }
@@ -376,6 +380,63 @@ pre {
   word-break: break-word;
   font-size: 0.86rem;
   line-height: 1.4;
+}
+
+.summary-section,
+.resume-form {
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  background: #12161e;
+}
+
+.section-label {
+  display: block;
+  color: #8b93a1;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.summary-output {
+  margin: 8px 0 0;
+  color: #dce2eb;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+.resume-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.resume-help {
+  margin: 6px 0 0;
+  color: #8b93a1;
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.resume-form textarea {
+  width: 100%;
+  min-height: 120px;
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: #171b24;
+  color: #eef2f8;
+  resize: vertical;
+}
+
+.resume-form textarea:focus {
+  outline: 1px solid rgba(93, 136, 255, 0.45);
+  border-color: rgba(93, 136, 255, 0.45);
 }
 
 .error-banner {

--- a/internal/sessionui/frontend/src/types.ts
+++ b/internal/sessionui/frontend/src/types.ts
@@ -2,6 +2,7 @@ export type SessionStatus =
   | "pending"
   | "scheduled"
   | "running"
+  | "blocked"
   | "idle"
   | "done"
   | "failed"
@@ -34,6 +35,11 @@ export type Session = {
   currentIteration?: number;
   maxIterations?: number;
   currentSkill?: string;
+  lastSkillOutput?: string;
+  blockReason?: string;
+  resumeSkill?: string;
+  resumePrompt?: string;
+  previousSummary?: string;
   idleTimeoutSeconds: number;
   maxRestarts: number;
   restartCount: number;

--- a/internal/sessionui/frontend/src/utils.ts
+++ b/internal/sessionui/frontend/src/utils.ts
@@ -3,6 +3,7 @@ import type { ErrorPayload, Session, SessionGroup, SessionStatus } from "./types
 export const STATUS_OPTIONS = [
   "all",
   "running",
+  "blocked",
   "scheduled",
   "failed",
   "done",
@@ -61,11 +62,13 @@ export function statusToneClass(status: SessionStatus): string {
       return "tone-green";
     case "scheduled":
       return "tone-blue";
+    case "blocked":
+      return "tone-amber";
+    case "done":
+      return "tone-green";
     case "failed":
     case "stopped":
       return "tone-red";
-    case "done":
-      return "tone-amber";
     default:
       return "tone-slate";
   }

--- a/internal/sessionui/server.go
+++ b/internal/sessionui/server.go
@@ -22,6 +22,7 @@ type sessionStore struct {
 	load       func(repoRoot, id string) (*session.Metadata, error)
 	reconcile  func(meta *session.Metadata) error
 	stop       func(meta *session.Metadata) error
+	resume     func(meta *session.Metadata, prompt string) error
 	deleteByID func(repoRoot, id string) error
 	readFile   func(path string) ([]byte, error)
 }
@@ -65,6 +66,11 @@ type sessionDTO struct {
 	CurrentIteration   int            `json:"currentIteration,omitempty"`
 	MaxIterations      int            `json:"maxIterations,omitempty"`
 	CurrentSkill       string         `json:"currentSkill,omitempty"`
+	LastSkillOutput    string         `json:"lastSkillOutput,omitempty"`
+	BlockReason        string         `json:"blockReason,omitempty"`
+	ResumeSkill        string         `json:"resumeSkill,omitempty"`
+	ResumePrompt       string         `json:"resumePrompt,omitempty"`
+	PreviousSummary    string         `json:"previousSummary,omitempty"`
 	IdleTimeoutSeconds int            `json:"idleTimeoutSeconds"`
 	MaxRestarts        int            `json:"maxRestarts"`
 	RestartCount       int            `json:"restartCount"`
@@ -80,6 +86,10 @@ type logResponse struct {
 
 type pruneRequest struct {
 	All bool `json:"all"`
+}
+
+type resumeRequest struct {
+	Prompt string `json:"prompt"`
 }
 
 type pruneResponse struct {
@@ -102,10 +112,20 @@ func NewHandler(repoRoot string) (http.Handler, error) {
 	h := &handler{
 		repoRoot: repoRoot,
 		store: sessionStore{
-			list:       session.List,
-			load:       session.LoadByID,
-			reconcile:  session.Reconcile,
-			stop:       session.Stop,
+			list:      session.List,
+			load:      session.LoadByID,
+			reconcile: session.Reconcile,
+			stop:      session.Stop,
+			resume: func(meta *session.Metadata, prompt string) error {
+				command, err := session.BuildResumeCommand(meta, prompt)
+				if err != nil {
+					return err
+				}
+				if err := session.UpdateCommand(meta, command); err != nil {
+					return err
+				}
+				return session.Start(meta)
+			},
 			deleteByID: session.DeleteByID,
 			readFile:   os.ReadFile,
 		},
@@ -117,6 +137,7 @@ func NewHandler(repoRoot string) (http.Handler, error) {
 	mux.HandleFunc("GET /api/sessions/{id}", h.handleGetSession)
 	mux.HandleFunc("GET /api/sessions/{id}/logs/{stream}", h.handleGetLog)
 	mux.HandleFunc("POST /api/sessions/{id}/stop", h.handleStopSession)
+	mux.HandleFunc("POST /api/sessions/{id}/resume", h.handleResumeSession)
 	mux.HandleFunc("DELETE /api/sessions/{id}", h.handleDeleteSession)
 	mux.HandleFunc("POST /api/sessions/prune", h.handlePruneSessions)
 	mux.Handle("/", h.handleSPA())
@@ -190,6 +211,32 @@ func (h *handler) handleStopSession(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.store.stop(meta); err != nil {
 		writeError(w, http.StatusBadGateway, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toSessionDTO(meta))
+}
+
+func (h *handler) handleResumeSession(w http.ResponseWriter, r *http.Request) {
+	meta, err := h.loadRunSession(r.PathValue("id"))
+	if err != nil {
+		h.writeSessionError(w, err)
+		return
+	}
+
+	var req resumeRequest
+	if r.Body != nil {
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeErrorMessage(w, http.StatusBadRequest, "invalid resume request")
+			return
+		}
+	}
+
+	if err := h.store.resume(meta, req.Prompt); err != nil {
+		writeError(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -354,6 +401,11 @@ func toSessionDTO(meta *session.Metadata) sessionDTO {
 		CurrentIteration:   meta.CurrentIteration,
 		MaxIterations:      meta.MaxIterations,
 		CurrentSkill:       meta.CurrentSkill,
+		LastSkillOutput:    meta.LastSkillOutput,
+		BlockReason:        meta.BlockReason,
+		ResumeSkill:        meta.ResumeSkill,
+		ResumePrompt:       meta.ResumePrompt,
+		PreviousSummary:    previousSummary(meta),
 		IdleTimeoutSeconds: meta.IdleTimeoutSeconds,
 		MaxRestarts:        meta.MaxRestarts,
 		RestartCount:       meta.RestartCount,
@@ -380,6 +432,14 @@ func formatSessionDetail(meta *session.Metadata) string {
 			return fmt.Sprintf("iter: %d/%d", meta.CurrentIteration, meta.MaxIterations)
 		}
 		return "last_output: " + meta.LastOutputAt.Local().Format(time.DateTime)
+	case session.StatusBlocked:
+		if meta.BlockReason != "" {
+			return "awaiting input: " + meta.BlockReason
+		}
+		if meta.ResumeSkill != "" {
+			return "awaiting input for " + meta.ResumeSkill
+		}
+		return "awaiting human input"
 	case session.StatusFailed, session.StatusStopped:
 		if meta.LastError != "" {
 			return meta.LastError
@@ -435,6 +495,32 @@ func readLogFile(readFile func(path string) ([]byte, error), path string, tail i
 		content = tailLines(content, tail)
 	}
 	return content, nil
+}
+
+func previousSummary(meta *session.Metadata) string {
+	if strings.TrimSpace(meta.LastSkillOutput) != "" {
+		return strings.TrimSpace(meta.LastSkillOutput)
+	}
+	return extractPreviousSummary(meta.ResumePrompt)
+}
+
+func extractPreviousSummary(prompt string) string {
+	trimmed := strings.TrimSpace(prompt)
+	if trimmed == "" {
+		return ""
+	}
+
+	const marker = "Previous skill stdout:\n"
+	idx := strings.Index(trimmed, marker)
+	if idx == -1 {
+		return trimmed
+	}
+
+	summary := strings.TrimSpace(trimmed[idx+len(marker):])
+	if summary == "" {
+		return trimmed
+	}
+	return summary
 }
 
 func tailLines(s string, n int) string {

--- a/internal/sessionui/server_test.go
+++ b/internal/sessionui/server_test.go
@@ -15,20 +15,21 @@ import (
 func TestListSessionsFiltersAndFormats(t *testing.T) {
 	now := time.Date(2026, 3, 7, 8, 9, 10, 0, time.UTC)
 	running := &session.Metadata{
-		ID:           "run-1",
-		WorkflowName: "nightly-review",
-		Skill:        "orchestrator",
-		Runtime:      "skill-loop",
-		RepoRoot:     "/repo",
-		ConfigPath:   "/repo/skill-loop.yml",
-		ScriptPath:   "/tmp/run-1/run.sh",
-		StdoutPath:   "/tmp/run-1/stdout.log",
-		StderrPath:   "/tmp/run-1/stderr.log",
-		ExitCodePath: "/tmp/run-1/exit.code",
-		Status:       session.StatusRunning,
-		StartedAt:    now,
-		LastOutputAt: now.Add(2 * time.Minute),
-		Command:      []string{"skill-loop", "run"},
+		ID:              "run-1",
+		WorkflowName:    "nightly-review",
+		Skill:           "orchestrator",
+		Runtime:         "skill-loop",
+		RepoRoot:        "/repo",
+		ConfigPath:      "/repo/skill-loop.yml",
+		ScriptPath:      "/tmp/run-1/run.sh",
+		StdoutPath:      "/tmp/run-1/stdout.log",
+		StderrPath:      "/tmp/run-1/stderr.log",
+		ExitCodePath:    "/tmp/run-1/exit.code",
+		Status:          session.StatusRunning,
+		StartedAt:       now,
+		LastOutputAt:    now.Add(2 * time.Minute),
+		LastSkillOutput: "latest stdout summary",
+		Command:         []string{"skill-loop", "run"},
 	}
 
 	h := &handler{
@@ -72,6 +73,9 @@ func TestListSessionsFiltersAndFormats(t *testing.T) {
 	}
 	if !strings.Contains(got.Sessions[0].Detail, "last_output:") {
 		t.Fatalf("detail = %q, want running summary", got.Sessions[0].Detail)
+	}
+	if got.Sessions[0].PreviousSummary != "latest stdout summary" {
+		t.Fatalf("previousSummary = %q, want latest stdout summary", got.Sessions[0].PreviousSummary)
 	}
 }
 
@@ -136,6 +140,70 @@ func TestDeleteSessionRejectsRunningSession(t *testing.T) {
 
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+}
+
+func TestResumeSession(t *testing.T) {
+	meta := &session.Metadata{
+		ID:          "blocked-1",
+		Skill:       "orchestrator",
+		Status:      session.StatusBlocked,
+		BlockReason: "waiting for approval",
+		ResumeSkill: "apply-feedback",
+	}
+
+	var gotPrompt string
+	h := &handler{
+		repoRoot: "/repo",
+		store: sessionStore{
+			load: func(repoRoot, id string) (*session.Metadata, error) {
+				return meta, nil
+			},
+			reconcile: func(meta *session.Metadata) error { return nil },
+			resume: func(meta *session.Metadata, prompt string) error {
+				gotPrompt = prompt
+				meta.Status = session.StatusRunning
+				meta.BlockReason = ""
+				meta.ResumeSkill = ""
+				return nil
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/blocked-1/resume", strings.NewReader(`{"prompt":"ship it"}`))
+	req.SetPathValue("id", "blocked-1")
+	rec := httptest.NewRecorder()
+
+	h.handleResumeSession(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if gotPrompt != "ship it" {
+		t.Fatalf("prompt = %q, want ship it", gotPrompt)
+	}
+}
+
+func TestExtractPreviousSummary(t *testing.T) {
+	got := extractPreviousSummary(strings.Join([]string{
+		"Previous skill: review",
+		"Selected route: ask-human",
+		"",
+		"Previous skill stdout:",
+		"<NEEDS_HUMAN>",
+	}, "\n"))
+	if got != "<NEEDS_HUMAN>" {
+		t.Fatalf("summary = %q, want %q", got, "<NEEDS_HUMAN>")
+	}
+}
+
+func TestPreviousSummaryPrefersLastSkillOutput(t *testing.T) {
+	meta := &session.Metadata{
+		LastSkillOutput: "latest",
+		ResumePrompt:    "Previous skill stdout:\nstale",
+	}
+	if got := previousSummary(meta); got != "latest" {
+		t.Fatalf("previousSummary() = %q, want latest", got)
 	}
 }
 

--- a/schema.json
+++ b/schema.json
@@ -86,6 +86,10 @@
         "done": {
           "type": "boolean",
           "description": "Terminate the workflow when this route is selected. Mutually exclusive with skill."
+        },
+        "blocked": {
+          "type": "boolean",
+          "description": "Pause the workflow and mark the session blocked awaiting human input. Requires skill and is mutually exclusive with done."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- add blocked session routing and resume support for human-in-the-loop workflows
- persist last skill output and expose blocked session resume controls in the sessions UI
- add e2e resume config plus tests and docs for the new flow

## Verification
- golangci-lint run
- go test ./...
- cd internal/sessionui/frontend && pnpm build