### PR TITLE
docs: add sessions show command to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ skill-loop run
 `skill-loop run` starts in background by default and prints a `run_id`.
 Use `skill-loop run --attach` to start detached and immediately attach to its tmux session.
 
+**5. Monitor sessions:**
+
+```bash
+skill-loop sessions show
+```
+
+Opens the embedded React dashboard in your browser to view and manage all sessions for the current repository.
+
 ---
 
 A typical `skill-loop.yml` looks like this:


### PR DESCRIPTION
## Summary

- Quick Startセクションにステップ5として `skill-loop sessions show` コマンドの使い方を追加
- ブラウザでダッシュボードを開いてセッションを管理できることを説明

## Test plan

- [ ] READMEのQuick Startセクションに新しいステップが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)